### PR TITLE
Fix failing tests after pandas 3 release

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -100,7 +100,7 @@ COVERAGE_CORE = "sysmon"
 
 [feature.optional.dependencies]
 dask-core = ">=2024.1.0"
-pandas = ">=2.1.0"
+pandas = ">=2.1.0, <3.0.0" # to avoid test failures in the new 3.0.0 release
 polars = ">=1.20.0"
 pyarrow = ">=14.0.0"
 pillow = ">=10.2.0"

--- a/pixi.toml
+++ b/pixi.toml
@@ -100,7 +100,7 @@ COVERAGE_CORE = "sysmon"
 
 [feature.optional.dependencies]
 dask-core = ">=2024.1.0"
-pandas = ">=2.1.0, <3.0.0" # to avoid test failures in the new 3.0.0 release
+pandas = ">=2.1.0"
 polars = ">=1.20.0"
 pyarrow = ">=14.0.0"
 pillow = ">=10.2.0"

--- a/tests/test_tabular.py
+++ b/tests/test_tabular.py
@@ -20,13 +20,13 @@ try:
     import numpy as np
     import pandas as pd
 
-    PANDAS_3 = pd.__version__.startswith("3.")
-    STR_DTYPE = "str" if PANDAS_3 else np.dtype("O")
-    DATETIME_DTYPE = np.dtype("datetime64[us]") if PANDAS_3 else np.dtype("datetime64[ns]")
+    PANDAS_GE_3 = int(pd.__version__.split(".")[0]) >= 3
+    PD_STR_DTYPE = "str" if PANDAS_GE_3 else np.dtype("O")
+    PD_DATETIME_DTYPE = np.dtype("datetime64[us]") if PANDAS_GE_3 else np.dtype("datetime64[ns]")
 except ImportError:
     # Pandas not installed, tests will skip anyway
-    STR_DTYPE = None
-    DATETIME_DTYPE = None
+    PD_STR_DTYPE = None
+    PD_DATETIME_DTYPE = None
 
 
 @pytest.mark.parametrize("dataset", datasets)
@@ -75,13 +75,13 @@ def test_penguins_schema(engine):
 
         expected_dtypes = pd.Series(
             {
-                "species": STR_DTYPE,
-                "island": STR_DTYPE,
+                "species": PD_STR_DTYPE,
+                "island": PD_STR_DTYPE,
                 "bill_length_mm": np.dtype("float64"),
                 "bill_depth_mm": np.dtype("float64"),
                 "flipper_length_mm": np.dtype("float64"),
                 "body_mass_g": np.dtype("float64"),
-                "sex": STR_DTYPE,
+                "sex": PD_STR_DTYPE,
                 "year": np.dtype("int64"),
             }
         )
@@ -187,7 +187,7 @@ def test_earthquakes_schema(engine):
 
         expected_dtypes = pd.Series(
             {
-                "time": DATETIME_DTYPE,
+                "time": PD_DATETIME_DTYPE,
                 "lat": np.dtype("float64"),
                 "lon": np.dtype("float64"),
                 "depth": np.dtype("float64"),
@@ -198,7 +198,7 @@ def test_earthquakes_schema(engine):
                 "mag_class": pd.CategoricalDtype(
                     categories=["Light", "Moderate", "Strong", "Major"], ordered=True
                 ),
-                "place": STR_DTYPE,
+                "place": PD_STR_DTYPE,
             }
         )
         pd.testing.assert_series_equal(df.dtypes, expected_dtypes)
@@ -231,7 +231,7 @@ def test_earthquakes_schema_lazy(engine):
 
         expected_dtypes = pd.Series(
             {
-                "time": DATETIME_DTYPE,
+                "time": PD_DATETIME_DTYPE,
                 "lat": np.dtype("float64"),
                 "lon": np.dtype("float64"),
                 "depth": np.dtype("float64"),
@@ -302,7 +302,7 @@ def test_apple_stocks_schema(engine):
 
         expected_dtypes = pd.Series(
             {
-                "date": DATETIME_DTYPE,
+                "date": PD_DATETIME_DTYPE,
                 "open": np.dtype("float64"),
                 "high": np.dtype("float64"),
                 "low": np.dtype("float64"),
@@ -339,7 +339,7 @@ def test_apple_stocks_schema_lazy(engine):
 
         expected_dtypes = pd.Series(
             {
-                "date": DATETIME_DTYPE,
+                "date": PD_DATETIME_DTYPE,
                 "open": np.dtype("float64"),
                 "high": np.dtype("float64"),
                 "low": np.dtype("float64"),
@@ -376,7 +376,7 @@ def test_stocks_schema(engine):
 
         expected_dtypes = pd.Series(
             {
-                "date": DATETIME_DTYPE,
+                "date": PD_DATETIME_DTYPE,
                 "Apple": np.dtype("float64"),
                 "Amazon": np.dtype("float64"),
                 "Google": np.dtype("float64"),
@@ -413,7 +413,7 @@ def test_stocks_schema_lazy(engine):
 
         expected_dtypes = pd.Series(
             {
-                "date": DATETIME_DTYPE,
+                "date": PD_DATETIME_DTYPE,
                 "Apple": np.dtype("float64"),
                 "Amazon": np.dtype("float64"),
                 "Google": np.dtype("float64"),
@@ -539,7 +539,7 @@ def test_us_states_schema(engine):
 
         expected_dtypes = pd.Series(
             {
-                "state": STR_DTYPE,
+                "state": PD_STR_DTYPE,
                 "median_income": np.dtype("float64"),
                 "income_range": pd.CategoricalDtype(),
                 "pop_density": np.dtype("float64"),

--- a/tests/test_tabular.py
+++ b/tests/test_tabular.py
@@ -13,6 +13,21 @@ datasets = [
     hvs.stocks,
 ]
 
+# Pandas 3.0 release had some breaking changes.
+# See https://pandas.pydata.org/docs/whatsnew/v3.0.0.html
+# Define dtype expectations based on pandas version
+try:
+    import numpy as np
+    import pandas as pd
+
+    PANDAS_3 = pd.__version__.startswith("3.")
+    STR_DTYPE = "str" if PANDAS_3 else np.dtype("O")
+    DATETIME_DTYPE = np.dtype("datetime64[us]") if PANDAS_3 else np.dtype("datetime64[ns]")
+except ImportError:
+    # Pandas not installed, tests will skip anyway
+    STR_DTYPE = None
+    DATETIME_DTYPE = None
+
 
 @pytest.mark.parametrize("dataset", datasets)
 @pytest.mark.parametrize("engine", list(_EAGER_TABULAR_LOOKUP))
@@ -60,13 +75,13 @@ def test_penguins_schema(engine):
 
         expected_dtypes = pd.Series(
             {
-                "species": np.dtype("O"),
-                "island": np.dtype("O"),
+                "species": STR_DTYPE,
+                "island": STR_DTYPE,
                 "bill_length_mm": np.dtype("float64"),
                 "bill_depth_mm": np.dtype("float64"),
                 "flipper_length_mm": np.dtype("float64"),
                 "body_mass_g": np.dtype("float64"),
-                "sex": np.dtype("O"),
+                "sex": STR_DTYPE,
                 "year": np.dtype("int64"),
             }
         )
@@ -172,7 +187,7 @@ def test_earthquakes_schema(engine):
 
         expected_dtypes = pd.Series(
             {
-                "time": np.dtype("datetime64[ns]"),
+                "time": DATETIME_DTYPE,
                 "lat": np.dtype("float64"),
                 "lon": np.dtype("float64"),
                 "depth": np.dtype("float64"),
@@ -183,7 +198,7 @@ def test_earthquakes_schema(engine):
                 "mag_class": pd.CategoricalDtype(
                     categories=["Light", "Moderate", "Strong", "Major"], ordered=True
                 ),
-                "place": np.dtype("O"),
+                "place": STR_DTYPE,
             }
         )
         pd.testing.assert_series_equal(df.dtypes, expected_dtypes)
@@ -216,7 +231,7 @@ def test_earthquakes_schema_lazy(engine):
 
         expected_dtypes = pd.Series(
             {
-                "time": np.dtype("datetime64[ns]"),
+                "time": DATETIME_DTYPE,
                 "lat": np.dtype("float64"),
                 "lon": np.dtype("float64"),
                 "depth": np.dtype("float64"),
@@ -287,7 +302,7 @@ def test_apple_stocks_schema(engine):
 
         expected_dtypes = pd.Series(
             {
-                "date": np.dtype("datetime64[ns]"),
+                "date": DATETIME_DTYPE,
                 "open": np.dtype("float64"),
                 "high": np.dtype("float64"),
                 "low": np.dtype("float64"),
@@ -324,7 +339,7 @@ def test_apple_stocks_schema_lazy(engine):
 
         expected_dtypes = pd.Series(
             {
-                "date": np.dtype("datetime64[ns]"),
+                "date": DATETIME_DTYPE,
                 "open": np.dtype("float64"),
                 "high": np.dtype("float64"),
                 "low": np.dtype("float64"),
@@ -361,7 +376,7 @@ def test_stocks_schema(engine):
 
         expected_dtypes = pd.Series(
             {
-                "date": np.dtype("datetime64[ns]"),
+                "date": DATETIME_DTYPE,
                 "Apple": np.dtype("float64"),
                 "Amazon": np.dtype("float64"),
                 "Google": np.dtype("float64"),
@@ -398,7 +413,7 @@ def test_stocks_schema_lazy(engine):
 
         expected_dtypes = pd.Series(
             {
-                "date": np.dtype("datetime64[ns]"),
+                "date": DATETIME_DTYPE,
                 "Apple": np.dtype("float64"),
                 "Amazon": np.dtype("float64"),
                 "Google": np.dtype("float64"),
@@ -524,7 +539,7 @@ def test_us_states_schema(engine):
 
         expected_dtypes = pd.Series(
             {
-                "state": np.dtype("O"),
+                "state": STR_DTYPE,
                 "median_income": np.dtype("float64"),
                 "income_range": pd.CategoricalDtype(),
                 "pop_density": np.dtype("float64"),


### PR DESCRIPTION
This PR updates the  tests to account for breaking changes introduced in pandas 3.0, and also ensures backward compatibility.
